### PR TITLE
Activate auditlog for users and groups in Redmine 4.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ Redmine Auditlog
 
 Provides full auditlog for user actions in Redmine instance.
 
-### Warning
-
-Under Redmine 4.x User and Group objects are not currently audited!
-
 
 How to use
 -------

--- a/init.rb
+++ b/init.rb
@@ -54,9 +54,12 @@ Redmine::Plugin.register :redmine_auditlog do
     WorkflowRule.send(:include, RedmineAuditlog::AuditlogPatch)
     WorkflowTransition.send(:include, RedmineAuditlog::AuditlogPatch)
 
-    if Redmine::VERSION::MAJOR < 4
-      User.send(:include, RedmineAuditlog::AuditlogPatchUser)
-      Group.send(:include, RedmineAuditlog::AuditlogPatch)
-    end
+    AnonymousUser.send(:include, RedmineAuditlog::AuditlogPatchUser)
+    User.send(:include, RedmineAuditlog::AuditlogPatchUser)
+
+    GroupNonMember.send(:include, RedmineAuditlog::AuditlogPatch)
+    GroupAnonymous.send(:include, RedmineAuditlog::AuditlogPatch)
+    GroupBuiltin.send(:include, RedmineAuditlog::AuditlogPatch)
+    Group.send(:include, RedmineAuditlog::AuditlogPatch)
   end
 end


### PR DESCRIPTION
It is necessary to also include sub classes that extend the classes User and Group. This helped me to get rid of the error on startup.
The reason for this can probably be found here: https://github.com/rails/rails/blob/26521331e5923a0c50fa50984d2f924e5f26c50b/activesupport/lib/active_support/callbacks.rb#L625 where there is an iteration over all subclasses of the class that is mentioned in <code>init.rb</code>.